### PR TITLE
waypoint_replanner configuration parameter cleanup

### DIFF
--- a/autoware_config_msgs/msg/ConfigWaypointReplanner.msg
+++ b/autoware_config_msgs/msg/ConfigWaypointReplanner.msg
@@ -5,14 +5,10 @@ float32 velocity_max
 float32 velocity_min
 float32 accel_limit
 float32 decel_limit
-float32 radius_thresh
+float32 lateral_accel_limit
 float32 radius_min
 bool resample_mode
 float32 resample_interval
-int32 velocity_offset
-int32 end_point_offset
-int32 braking_distance
 bool replan_curve_mode
 bool replan_endpoint_mode
-bool overwrite_vmax_mode
 bool realtime_tuning_mode


### PR DESCRIPTION
Removed the following configuration parameters for waypoint_replanner: 
```
float32 radius_thresh
int32 velocity_offset
int32 end_point_offset
int32 braking_distance
bool overwrite_vmax_mode
```
And one new configuration parameter
```
float32 lateral_accel_limit
```

See original MR for more details: https://gitlab.com/astuff/autoware.ai/messages/-/merge_requests/11